### PR TITLE
Avoid zero divisions causing "nan" values

### DIFF
--- a/successrate.sh
+++ b/successrate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 #A StorJ node monitor script for telegraf using [inputs.exec]
 #Visualizing StorJ V3 node health with Grafana
 
@@ -25,6 +27,9 @@ audit_failed_warn=$($LOG 2>&1 | grep GET_AUDIT | grep failed | grep -v open -c)
 audit_success=$($LOG 2>&1 | grep GET_AUDIT | grep downloaded -c)
 #Ratio of Successful to Failed Audits
 audit_ratio=$(printf '%.3f\n' $(echo "$audit_success $audit_failed_crit $audit_failed_warn" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))
+if [ "$audit_ratio" == "nan" ]; then
+  audit_ratio="100.000"
+fi
 
 #Failed Downloads from your node
 dl_failed=$($LOG 2>&1 | grep '"GET"' | grep failed -c)
@@ -32,6 +37,9 @@ dl_failed=$($LOG 2>&1 | grep '"GET"' | grep failed -c)
 dl_success=$($LOG 2>&1 | grep '"GET"' | grep downloaded -c)
 #Ratio of Failed Downloads
 dl_ratio=$(printf '%.3f\n' $(echo "$dl_success $dl_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))
+if [ "$dl_ratio" == "nan" ]; then
+  dl_ratio="100.000"
+fi
 
 #count of failed uploads to your node
 put_failed=$($LOG 2>&1 | grep '"PUT"' | grep failed -c)
@@ -39,9 +47,15 @@ put_failed=$($LOG 2>&1 | grep '"PUT"' | grep failed -c)
 put_success=$($LOG 2>&1 | grep '"PUT"' | grep uploaded -c)
 #Ratio of Uploads
 put_ratio=$(printf '%.3f\n' $(echo "$put_success $put_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))
+if [ "$put_ratio" == "nan" ]; then
+  put_ratio="100.000"
+fi
 #Uploads: count of concurrent connection max
 concurrent_limit=$($LOG 2>&1 | grep "upload rejected" -c)
 put_accept_ratio=$(printf '%.3f\n' $(echo "$put_success $concurrent_limit" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))
+if [ "$put_accept_ratio" == "nan" ]; then
+  put_accept_ratio="100.000"
+fi
 
 #count of failed downloads of pieces for repair process
 get_repair_failed=$($LOG 2>&1 | grep GET_REPAIR | grep failed -c)
@@ -49,6 +63,9 @@ get_repair_failed=$($LOG 2>&1 | grep GET_REPAIR | grep failed -c)
 get_repair_success=$($LOG 2>&1 | grep GET_REPAIR | grep downloaded -c)
 #Ratio of GET_REPAIR
 get_repair_ratio=$(printf '%.3f\n' $(echo "$get_repair_success $get_repair_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))
+if [ "$get_repair_ratio" == "nan" ]; then
+  get_repair_ratio="100.000"
+fi
 
 #count of failed uploads repaired pieces
 put_repair_failed=$($LOG 2>&1 | grep PUT_REPAIR | grep failed -c)
@@ -56,6 +73,9 @@ put_repair_failed=$($LOG 2>&1 | grep PUT_REPAIR | grep failed -c)
 put_repair_success=$($LOG 2>&1 | grep PUT_REPAIR | grep uploaded -c)
 #Ratio of PUT_REPAIR
 put_repair_ratio=$(printf '%.3f\n' $(echo "$put_repair_success $put_repair_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))
+if [ "$put_repair_ratio" == "nan" ]; then
+  put_repair_ratio="100.000"
+fi
 
 #InfoDB Health Check, disk image is malformed
 infodb_check=$($LOG 2>&1 | grep "disk image is malformed" -c)


### PR DESCRIPTION
Fixed division by zero for ratio values.
Also added an interpreter #!/bin/bash because my Telegraf instance (trough docker) needs it to run input.exec plugins.