### PR TITLE
Fix SNO dashboard API strucure change.

### DIFF
--- a/Dashboard/StorJ V3 Health-1563404207497.json
+++ b/Dashboard/StorJ V3 Health-1563404207497.json
@@ -3161,7 +3161,7 @@
             },
             {
               "params": [
-                "data_nodeID"
+                "nodeID"
               ],
               "type": "tag"
             },
@@ -3181,7 +3181,7 @@
             [
               {
                 "params": [
-                  "data_diskSpace_used"
+                  "diskSpace_used"
                 ],
                 "type": "field"
               },
@@ -3210,7 +3210,7 @@
             },
             {
               "params": [
-                "data_nodeID"
+                "nodeID"
               ],
               "type": "tag"
             },
@@ -3230,7 +3230,7 @@
             [
               {
                 "params": [
-                  "data_diskSpace_available"
+                  "diskSpace_available"
                 ],
                 "type": "field"
               },
@@ -3350,7 +3350,7 @@
             },
             {
               "params": [
-                "data_nodeID"
+                "nodeID"
               ],
               "type": "tag"
             },
@@ -3370,7 +3370,7 @@
             [
               {
                 "params": [
-                  "data_bandwidth_used"
+                  "bandwidth_used"
                 ],
                 "type": "field"
               },
@@ -3399,7 +3399,7 @@
             },
             {
               "params": [
-                "data_nodeID"
+                "nodeID"
               ],
               "type": "tag"
             },
@@ -3420,7 +3420,7 @@
             [
               {
                 "params": [
-                  "data_bandwidth_available"
+                  "bandwidth_available"
                 ],
                 "type": "field"
               },

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Add/Append this block to your telegraf.conf
 
   [[inputs.exec]]
      commands = [
-          "curl -s 127.0.0.1:14002/api/dashboard", # Open SNO API by mapping ports when running your SNO docker instance
-          "curl -s 127.0.0.1:14003/api/dashboard" # If multiple nodes, map ports accordingly
+          "curl -s 127.0.0.1:14002/api/sno", # Open SNO API by mapping ports when running your SNO docker instance
+          "curl -s 127.0.0.1:14003/api/sno" # If multiple nodes, map ports accordingly
           ]
      timeout = "60s"
      interval = "1m"
      data_format = "json"
-     tag_keys = [ "data_nodeID" ]
+     tag_keys = [ "nodeID" ]
      name_override = "StorJHealth"
 ```
 

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -247,11 +247,11 @@
 
 [[inputs.exec]]
   commands = [
-      "curl -s 127.0.0.1:14002/api/dashboard", # Open SNO API by mapping ports when running your SNO docker instance
-      "curl -s 127.0.0.1:14003/api/dashboard" # If multiple nodes, map ports accordingly
+      "curl -s 127.0.0.1:14002/api/sno", # Open SNO API by mapping ports when running your SNO docker instance
+      "curl -s 127.0.0.1:14003/api/sno" # If multiple nodes, map ports accordingly
       ]
   timeout = "60s"
   interval = "1m"
   data_format = "json"
-  tag_keys = [ "data_nodeID" ]
+  tag_keys = [ "nodeID" ]
   name_override = "StorJHealth"


### PR DESCRIPTION
This should address https://github.com/gsxryan/storj_telegraf_mon/issues/28
Some one please test as I got a divergent local copy of my Grafana dashboard.

Not retrocopatible change, for both bandwidth and disk space metrics. A quickfix is to add new queries to both graphs with old fields (i.e. data_bandwidth_used).

Also, bandwidth_available can be disabled as it has been deprecated.